### PR TITLE
Spec failure: new should generate mygame with template

### DIFF
--- a/spec/lib/entityjs/commands/new_spec.rb
+++ b/spec/lib/entityjs/commands/new_spec.rb
@@ -13,7 +13,7 @@ describe 'new' do
     Entityjs::New.generate(['mygame', 'blank']).should == 0
     Dir.pwd.should match /\/EntityJS$/i
     
-    File.exists?('mygame/config.yml').should == true
+    File.exists?('mygame/game.json').should == true
     File.exists?('mygame/readme.txt').should == true
   end
   


### PR DESCRIPTION
The spec in `spec/lib/entityjs/commands/new_spec.rb` fails because it's looking for `config.yml`, but that was changed to `config.json` in 4941e6614774a641042b449b9c61090f5d34733e and then to `game.json` in 0aa51d5faa782cd54c885fc9a1e01f72647d70cc.
