### PR TITLE
Spec failure: build should build

### DIFF
--- a/lib/entityjs/commands/build.rb
+++ b/lib/entityjs/commands/build.rb
@@ -19,6 +19,7 @@ module Entityjs
       images_folder = Config.images_folder
       sounds_folder = Config.sounds_folder
       scripts_folder = Config.scripts_folder
+      styles_folder = Config.instance.build_styles_path
       
       final_name = Config.instance.build_name+'.js'
       html_name = 'play.html'
@@ -60,7 +61,9 @@ module Entityjs
       end
       
       #save css
-      File.open(Config.instance.build_styles_path+"/"+Config.instance.build_styles_name+'.css', 'w') do |f|
+      Dirc.create_dir(styles_folder)
+
+      File.open(styles_folder+"/"+Config.instance.build_styles_name+'.css', 'w') do |f|
         f.write(css)
       end
       


### PR DESCRIPTION
The specs are failing on the 'build should build' task. This also happens when running `entityjs build` - it fails with:

```
Errno::ENOENT:
       No such file or directory - styles/game.min.css
```

This appears to be because the build command doesn't create the `styles` directory before attempting to write the CSS file.
