### PR TITLE
Spec failure: command outside entityjs dir

### DIFF
--- a/spec/support/mygame.rb
+++ b/spec/support/mygame.rb
@@ -12,5 +12,5 @@ def setup_mygame
 end
 
 def teardown_mygame
-  Dir.chdir('..')
+  Dir.chdir('..') if Entityjs::Dirc.game?
 end


### PR DESCRIPTION
The three sub-tasks of 'outside entityjs dir' in `spec/lib/entityjs/command_spec.rb` fail if the _parent directory_ contains a directory called `scripts`. For instance, I have:

```
~/Code/
|-- EntityJS
|-- <snipped>
|-- scripts <- causes specs to fail!
```

There are two problems I can see with the specs:
1. `teardown_mygame` doesn't check if it's in a game folder before moving up a level.
2. The definition uses `before(:all)` which only runs once; `before(:each)` is the instruction to run a setup / teardown task with each task. (See the docs: https://www.relishapp.com/rspec/rspec-core/docs/hooks/before-and-after-hooks.) I don't know what the intention was here, but that doesn't seem right. Even if the specs succeeded without fixing 1, they'd produce a test build in `./EntityJS/../build/` (`~/Code/build/` in the above example).
